### PR TITLE
Use inline-source-map instead of eval in development mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const dev = process.env.NODE_ENV === 'development';
 
 module.exports = {
   mode: dev ? 'development' : 'production',
+  devtool: dev ? 'inline-source-map' : false,
   output: {
     filename: `loglevelnext${dev ? '' : '.min'}.js`,
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
<!-- Please place an x (no spaces!) in all [ ] that apply -->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Changes are related to the build environment. No tests where added.

### Motivation / Use-Case

This enables usage of the dist dev version in environments where
a content security policy (CSP) forbids use of eval.

### Breaking Changes

No breaking changes.

### Additional Info

Additional discussion in #2.