### PR TITLE
Use console.debug when available

### DIFF
--- a/lib/factory/MethodFactory.js
+++ b/lib/factory/MethodFactory.js
@@ -92,11 +92,6 @@ module.exports = class MethodFactory {
    */
   // eslint-disable-next-line class-methods-use-this
   make(methodName) {
-    if (methodName === 'debug') {
-      // eslint-disable-next-line no-param-reassign
-      methodName = 'log';
-    }
-
     /* eslint-disable no-console */
     if (typeof console[methodName] !== 'undefined') {
       return this.bindMethod(console, methodName);

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -52,7 +52,7 @@ for (const name of Object.keys(log.levels)) {
   });
 
   test.serial(`logs only levels >= ${name}`, (t) => {
-    for (let method of spyMethods) {
+    for (const method of spyMethods) {
       let expected = 1;
 
       // NOTE: the [object Object] + stack output to console is part of the 'trace' test. fret not.
@@ -66,9 +66,6 @@ for (const name of Object.keys(log.levels)) {
         expected = 2;
       }
 
-      if (method === 'debug') {
-        method = 'log';
-      }
       t.is(console[method].callCount, expected);
     }
   });


### PR DESCRIPTION
Fixes #12 

<!-- PRs must be accompanied by related tests -->

Please check one:
- [ ] New tests created for this change
- [x] Tests updated for this change

This PR:
- [ ] Adds new API
- [x] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [ ] Fixes a bug

---

I think the existing fallback to console.log will work. Let's see if node 6 tests pass in CI.

<!-- add additional comments here -->
